### PR TITLE
Php curl requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Für die deutsche Version lese bitte das deutsche ReadMe.
 This PHP script is designed to be used with a Fritz!Box, but may also work with other routers and devices that offer the ability to call a custom URL and pass the IPv4 and IPv6 address. The Fritz!Box will call the script automatically as soon as the IPv4 and IPv6 address has been changed. The IP-addresses of the Fritz!Box are passed to the script.
 
 # Requirements
-Only a web server, a Cloudflare account (Free/Paid) and a domain registered with Cloudflare is required. The webserver only needs PHP and must be accessible via the internet. If necessary it also works with a server in your own network, but this has not been tested yet.
+Only a web server, a Cloudflare account (Free/Paid) and a domain registered with Cloudflare is required. The webserver only needs PHP, PHP-Curl and must be accessible via the internet. If necessary it also works with a server in your own network, but this has not been tested yet.
 
 # Features
 - Transmission of the current IP address of the Fritzbox to Cloudflare (via API)

--- a/README_de.md
+++ b/README_de.md
@@ -4,7 +4,7 @@ For English version, please read the English readme file.
 Dieses PHP Script ist für die Nutzung mit einer Fritz!Box ausgelegt, funktioniert aber möglicherweise auch mit anderen Routern und Geräten, die die Möglichkeit bieten eine benutzerdefinierte URL aufzurufen und die IPv4 und IPv6 Adresse übergeben können. Die Fritz!Box ruft das Script selbstständig auf, sobald die IP-Adresse geändert wurde. Dabei werden die IP-Adressen von der Fritz!Box an das Script übergeben.
 
 # Voraussetzungen
-Es wird lediglich ein Webserver, ein Cloudflare Account (Free/Paid) und eine Domain, die bei Cloudflare registriert ist, benötigt. Der Webserver benötigt lediglich PHP und muss natürlich über das Internet erreichbar sein. Ggf. funktioniert es auch mit einem Server im eigenen Netzwerk, das wurde bisher allerdings nicht getestet.
+Es wird lediglich ein Webserver, ein Cloudflare Account (Free/Paid) und eine Domain, die bei Cloudflare registriert ist, benötigt. Der Webserver benötigt lediglich PHP, PHP-Curl und muss natürlich über das Internet erreichbar sein. Ggf. funktioniert es auch mit einem Server im eigenen Netzwerk, das wurde bisher allerdings nicht getestet.
 
 # Funktionen
 - Übermittlung der aktuellen IP-Adresse der Fritzbox an Cloudflare (per API)


### PR DESCRIPTION
PHP-Curl is needed for the script to work. 
Else an `PHP Fatal error:  Uncaught Error: Call to undefined function curl_init()` will occur...